### PR TITLE
修复mac操作系统下的源码编译错误

### DIFF
--- a/patch/libs/python/src/converter/builtin_converters.cpp
+++ b/patch/libs/python/src/converter/builtin_converters.cpp
@@ -48,7 +48,7 @@ namespace
 #else
   void* convert_to_cstring(PyObject* obj)
   {
-      return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
+      return PyUnicode_Check(obj) ? const_cast<char*>(_PyUnicode_AsString(obj)) : 0;
   }
 #endif
 


### PR DESCRIPTION
操作系统： macOS Mojave (10.14.3)
python版本：Python 3.7.1
clang++ 版本：Apple LLVM version 10.0.0 (clang-1000.11.45.5)  Target: x86_64-apple-darwin18.2.0

执行python setup.py install出现如下错误：
```
patch/libs/python/src/converter/builtin_converters.cpp:51:14: error: cannot initialize return object of type 'void *' with an rvalue of type 'const char *'
      return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/xxx/anaconda3/include/python3.7m/unicodeobject.h:363:18: note: expanded from macro 'PyUnicode_Check'
                 PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_UNICODE_SUBCLASS)
                 ^
/Users/xxx/anaconda3/include/python3.7m/object.h:686:35: note: expanded from macro 'PyType_FastSubclass'
#define PyType_FastSubclass(t,f)  PyType_HasFeature(t,f)
                                  ^
/Users/xxx/anaconda3/include/python3.7m/object.h:684:33: note: expanded from macro 'PyType_HasFeature'
#define PyType_HasFeature(t,f)  (((t)->tp_flags & (f)) != 0)
                                ^
1 error generated.
error: command 'clang++' failed with exit status 1
```
