### PR TITLE
bugfix:builtin_converters.cpp : convert_to_cstring

### DIFF
--- a/patch/libs/python/src/converter/builtin_converters.cpp
+++ b/patch/libs/python/src/converter/builtin_converters.cpp
@@ -48,7 +48,7 @@ namespace
 #else
   void* convert_to_cstring(PyObject* obj)
   {
-      return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
+      return (void *)(PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0);
   }
 #endif
 


### PR DESCRIPTION

Bug Fix : builtin_converters.cpp : convert_to_cstring in GCC7.3.0

## Description Changes

Add a cast to  `void * ` manually.  
file:  [/patch/libs/python/src/converter/builtin_converters.cpp](/patch/libs/python/src/converter/builtin_converters.cpp)

```patch
  void* convert_to_cstring(PyObject* obj)
  {
-    return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;
+    return (void *)(PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0);
  }
```

see #191 .

## Motivation and Context
When install pyltp with gcc 7.3.0. A error occurs.

```
patch/libs/python/src/converter/builtin_converters.cpp: In function ‘void* boost::python::converter::{anonymous}::convert_to_cstring(PyObject*)’:
patch/libs/python/src/converter/builtin_converters.cpp:51:35: error: invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
       return PyUnicode_Check(obj) ? _PyUnicode_AsString(obj) : 0;

error: command 'gcc' failed with exit status 1
```
Context:
```
Linux version 4.15.0-45-generic (buildd@lgw01-amd64-031) (gcc version 7.3.0 (Ubuntu 7.3.0-16ubuntu3)) #48-Ubuntu SMP Tue Jan 29 16:28:13 UTC 2019

gcc version 7.3.0 (Ubuntu 7.3.0-27ubuntu1~18.04) 

Python 3.5.6 :: Anaconda, Inc.

```


## How Has This Been Tested?
  Yes  


## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:


- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

- [ ] 