### PR TITLE
增加了使用python-list类型作为句法弧，输入srl的方法。

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ ext_modules = [Extension('pyltp',
 
 setup(
     name='pyltp',
-    version='0.2.1',
+    version='0.2.3',
     description='pyltp: the python extension for LTP',
     long_description=codecs.open('README.md', encoding='utf-8').read(),
     author='Yijia Liu, Zixiang Xu, Yang Liu',

--- a/src/pyltp.cpp
+++ b/src/pyltp.cpp
@@ -334,6 +334,14 @@ struct SementicRoleLabeller {
     return label(py_list_to_std_vector<std::string>(words), py_list_to_std_vector<std::string>(postags), parse);
   }
 
+  std::vector<SementicRole> label(
+      const boost::python::list& words,
+      const boost::python::list& postags,
+      const boost::python::list& parse
+      ) {
+    return label(words, postags, py_list_to_std_vector<ParseResult>(parse));
+  }
+
   void release() {
     if (loaded) {
       srl_release_resource();
@@ -427,6 +435,7 @@ BOOST_PYTHON_MODULE(pyltp)
     .def("label", static_cast<std::vector<SementicRole> (SementicRoleLabeller::*)(const std::vector<std::string>&, const boost::python::list&, const std::vector<ParseResult>&)>(&SementicRoleLabeller::label))
     .def("label", static_cast<std::vector<SementicRole> (SementicRoleLabeller::*)(const boost::python::list&, const std::vector<std::string>&, const std::vector<ParseResult>&)>(&SementicRoleLabeller::label))
     .def("label", static_cast<std::vector<SementicRole> (SementicRoleLabeller::*)(const boost::python::list&, const boost::python::list&, const std::vector<ParseResult>&)>(&SementicRoleLabeller::label))
+    .def("label", static_cast<std::vector<SementicRole> (SementicRoleLabeller::*)(const boost::python::list&, const boost::python::list&, const boost::python::list&)>(&SementicRoleLabeller::label))
     .def("release", &SementicRoleLabeller::release)
     ;
 }


### PR DESCRIPTION
之前是内置vector类型，需要使用parser的输出结构。无法自己构造句法结构。此改动增加了此位置类型转换。